### PR TITLE
fixed #18 - using now S3DB_DATABASE_CONFIG env variable when configuring...

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    s3db-backup (0.8.1)
+    s3db-backup (0.8.2)
       right_aws (>= 2.0.0)
 
 GEM

--- a/lib/s3db/configuration.rb
+++ b/lib/s3db/configuration.rb
@@ -14,7 +14,8 @@ module S3db
     private
 
     def configure_db
-      ActiveRecord::Base.configurations[::Rails.env]
+      database_config = ENV['S3DB_DATABASE_CONFIG'] || ::Rails.env
+      ActiveRecord::Base.configurations[database_config]
     end
 
     def configure_aws

--- a/lib/s3db/loader.rb
+++ b/lib/s3db/loader.rb
@@ -16,7 +16,6 @@ module S3db
     end
 
     def load
-      choose_database
       recreate_database
       load_dump
       anonymize_database
@@ -30,10 +29,6 @@ module S3db
     end
 
     private
-
-    def choose_database
-      config.db['database'] = ENV['S3DB_DATABASE'] if ENV['S3DB_DATABASE']
-    end
 
     def recreate_database
       puts "** using database configuration for environment: '#{::Rails.env}'"

--- a/lib/s3db/version.rb
+++ b/lib/s3db/version.rb
@@ -1,3 +1,3 @@
 module S3db
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end

--- a/spec/s3db/configuration_spec.rb
+++ b/spec/s3db/configuration_spec.rb
@@ -7,9 +7,21 @@ describe S3db::Configuration do
   end
 
   describe "initialize" do
-    it "loads the db config" do
-      config = S3db::Configuration.new
-      config.db.should == rails_configurations['test']
+
+    context "without environment S3DB_DATABASE_CONFIG" do
+      it "loads the db config for the current RAILS_ENV" do
+        config = S3db::Configuration.new
+        config.db.should == rails_configurations['test']
+      end
+    end
+
+    context "with environment S3DB_DATABASE_CONFIG" do
+      it "loads the db config identified by the env variable" do
+        ENV['S3DB_DATABASE_CONFIG'] = "other_db_config"
+        config = S3db::Configuration.new
+        config.db.should == rails_configurations['other_db_config']
+        ENV['S3DB_DATABASE_CONFIG'] = nil
+      end
     end
 
     it "loads the aws config" do
@@ -17,21 +29,21 @@ describe S3db::Configuration do
       config.aws.should == s3_config_yml_contents.merge({'bucket' => 's3db_backup_test_bucket'})
     end
 
-    it "sets the latest_dump_path" do
-      config = S3db::Configuration.new
-      config.latest_dump_path.should eql(File.join(::Rails.root, 'db', 'latest_dump.sql'))
-    end
-
-    describe "s3 config yml" do
-      describe "first-level key is missing" do
+    describe "handling of missing keys in s3_config.yml" do
+      context "when AWS authentication key is missing" do
         it "throws AwsConfigurationError" do
-          should_raise_error_if_missing_key('test')
           should_raise_error_if_missing_key('aws_access_key_id')
           should_raise_error_if_missing_key('secret_access_key')
         end
       end
 
-      describe "bucket is missing" do
+      context "when environment section is missing" do
+        it "throws AwsConfigurationError" do
+          should_raise_error_if_missing_key('test')
+        end
+      end
+
+      context "when bucket is missing in the section identified by current RAILS_ENV" do
         it "throws AwsConfigurationError" do
           incomplete_s3_config = s3_config_yml_contents
           env_config = incomplete_s3_config['test']

--- a/spec/s3db/loader_spec.rb
+++ b/spec/s3db/loader_spec.rb
@@ -43,21 +43,6 @@ describe S3db::Loader do
       loader.should_receive(:system).with(/mysql.*s3db_backup_test/)
       loader.load
     end
-
-    describe "environment S3DB_DATABASE is set" do
-      before do
-        ENV['S3DB_DATABASE'] = "my_development_db"
-      end
-
-      it "uses the given database" do
-        loader.should_receive(:system).with(/my_development_db/)
-        loader.load
-      end
-
-      after do
-        ENV['S3DB_DATABASE'] = nil
-      end
-    end
   end
 
   describe "anonymize_database" do

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -22,6 +22,13 @@ def rails_configurations
           "database" => "s3db_backup_test",
           "password" => "secret",
           "adapter" => "mysql2"
+      },
+      'other_db_config' => {
+        "username" => "my_app",
+        "encoding" => "utf8",
+        "database" => "my_other_db",
+        "password" => "another_secret",
+        "adapter" => "mysql2"
       }
   }
 end


### PR DESCRIPTION
... the run instead of only overwriting config.db[‘datbase']
