### PR TITLE
Minor Fixes: Gzip Compression, Password Enclosure

### DIFF
--- a/lib/s3db/command_line.rb
+++ b/lib/s3db/command_line.rb
@@ -35,7 +35,7 @@ module S3db
 
     def gzip_command
       gzip = locate_command_path('gzip')
-      "#{gzip} -9"
+      "#{gzip} -#{config.compression}"
     end
 
     def mysqldump_command

--- a/lib/s3db/command_line.rb
+++ b/lib/s3db/command_line.rb
@@ -59,7 +59,7 @@ module S3db
     def mysql_params
       command_chain = []
       command_chain << "--user=#{config.db['username']}"
-      command_chain << "--password=#{config.db['password']}" if config.db['password']
+      command_chain << "--password='#{config.db['password']}'" if config.db['password']
       command_chain << "--host=#{config.db['host']}" if config.db['host']
       command_chain << "--port=#{config.db['port']}" if config.db['port']
       command_chain.join(" ")

--- a/lib/s3db/command_line.rb
+++ b/lib/s3db/command_line.rb
@@ -62,6 +62,13 @@ module S3db
       command_chain << "--password='#{config.db['password']}'" if config.db['password']
       command_chain << "--host=#{config.db['host']}" if config.db['host']
       command_chain << "--port=#{config.db['port']}" if config.db['port']
+
+      if config.mysql_options.any?
+        config.mysql_options.each do |custom_command|
+          command_chain << "--#{custom_command}"
+        end
+      end
+
       command_chain.join(" ")
     end
   end

--- a/lib/s3db/configuration.rb
+++ b/lib/s3db/configuration.rb
@@ -3,11 +3,13 @@ module S3db
 
     attr_reader :db
     attr_reader :aws
+    attr_reader :compression
     attr_reader :latest_dump_path
 
     def initialize
       @db = configure_db
       @aws = configure_aws
+      @compression = @aws.fetch('compression', '9')
       @latest_dump_path = File.join(::Rails.root, 'db', "latest_dump.sql")
     end
 

--- a/lib/s3db/configuration.rb
+++ b/lib/s3db/configuration.rb
@@ -42,7 +42,7 @@ module S3db
 
   class AwsConfigurationError < StandardError
     def initialize(key)
-      super("Please specify your #{key} in config/s3config.yml")
+      super("Please specify your #{key} in config/s3_config.yml")
     end
   end
 end

--- a/lib/s3db/configuration.rb
+++ b/lib/s3db/configuration.rb
@@ -4,12 +4,14 @@ module S3db
     attr_reader :db
     attr_reader :aws
     attr_reader :compression
+    attr_reader :mysql_options
     attr_reader :latest_dump_path
 
     def initialize
       @db = configure_db
       @aws = configure_aws
       @compression = @aws.fetch('compression', '9')
+      @mysql_options = @aws.fetch('mysql_options', [])
       @latest_dump_path = File.join(::Rails.root, 'db', "latest_dump.sql")
     end
 

--- a/spec/s3db/command_line_spec.rb
+++ b/spec/s3db/command_line_spec.rb
@@ -2,6 +2,10 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 describe S3db::CommandLine do
 
   let(:command_line) { S3db::CommandLine.new(S3db::Configuration.new) }
+  let(:custom_command_line) {
+      YAML.stub(:load_file => s3_config_yml_contents.merge({'mysql_options' => ['quick', 'single-transaction']}))
+      S3db::CommandLine.new(S3db::Configuration.new)
+  }
 
   before do
     stub_configuration
@@ -14,6 +18,10 @@ describe S3db::CommandLine do
 
     it "includes mysqldump into the command" do
       command_line.dump_command(tempfile).should =~ /mysqldump --user=app --password='secret' s3db_backup_test/
+    end
+
+    it "includes custom mysqldump commands" do
+      custom_command_line.dump_command(tempfile).should =~ /mysqldump --user=app --password='secret' --quick --single-transaction s3db_backup_test/
     end
 
     it "includes gzip into the command" do

--- a/spec/s3db/command_line_spec.rb
+++ b/spec/s3db/command_line_spec.rb
@@ -13,7 +13,7 @@ describe S3db::CommandLine do
     let(:tempfile) { stub(:path => "/foobar") }
 
     it "includes mysqldump into the command" do
-      command_line.dump_command(tempfile).should =~ /mysqldump --user=app --password=secret s3db_backup_test/
+      command_line.dump_command(tempfile).should =~ /mysqldump --user=app --password='secret' s3db_backup_test/
     end
 
     it "includes gzip into the command" do
@@ -34,7 +34,7 @@ describe S3db::CommandLine do
     let(:latest_dump) { File.join(Rails.root, "db", "latest_prod_dump.sql") }
 
     it "includes mysql into the command" do
-      command_line.load_command(anything).should =~ /mysql --user=app --password=secret --database=s3db_backup_test/
+      command_line.load_command(anything).should =~ /mysql --user=app --password='secret' --database=s3db_backup_test/
     end
 
     describe "db host and port are given" do

--- a/spec/s3db/configuration_spec.rb
+++ b/spec/s3db/configuration_spec.rb
@@ -40,6 +40,12 @@ describe S3db::Configuration do
       config.compression.should == '6'
     end
 
+    it "should allow you to define custom mysqldump parameters" do
+      YAML.stub(:load_file => s3_config_yml_contents.merge({'mysql_options' => ['quick', 'single-transaction']}))
+      config = S3db::Configuration.new
+      config.mysql_options == ['quick', 'single-transaction']
+    end
+
     describe "handling of missing keys in s3_config.yml" do
       context "when AWS authentication key is missing" do
         it "throws AwsConfigurationError" do

--- a/spec/s3db/configuration_spec.rb
+++ b/spec/s3db/configuration_spec.rb
@@ -29,6 +29,17 @@ describe S3db::Configuration do
       config.aws.should == s3_config_yml_contents.merge({'bucket' => 's3db_backup_test_bucket'})
     end
 
+    it "should use the default gzip compression rate of 9" do
+      config = S3db::Configuration.new
+      config.compression.should == '9'
+    end
+
+    it "should allow you to override the compression used in gzip" do
+      YAML.stub(:load_file => s3_config_yml_contents.merge({'compression' => '6'}))
+      config = S3db::Configuration.new
+      config.compression.should == '6'
+    end
+
     describe "handling of missing keys in s3_config.yml" do
       context "when AWS authentication key is missing" do
         it "throws AwsConfigurationError" do


### PR DESCRIPTION
Howdy, just a few minor changes.
1. I've enclosed the password in quotations. If your mysql password contained special characters (such as $) the command to connect to the database would not work. By wrapping them this safeguards things. Specs updated.
2. Minor type-o in error that caught be up, specified s3config, when should of been s3_config
3. Allowed the compression rate of gzip to be specified in the s3_config file under the key 'compression'. Using a compression rate of -9 was effecting the CPU to the point where it would impact our site. This should allow anyone who wants to, to reduce it. 
