### PR TITLE
Using ERB when reading the config YAML file.

### DIFF
--- a/lib/s3db/configuration.rb
+++ b/lib/s3db/configuration.rb
@@ -23,7 +23,9 @@ module S3db
     end
 
     def configure_aws
-      aws = YAML::load_file(File.join(Rails.root, "config", "s3_config.yml"))
+      template = ERB.new File.new(File.join(Rails.root, "config", "s3_config.yml")).read
+      aws = YAML.load template.result(binding)
+      
       validate_presence_of(aws, 'aws_access_key_id')
       validate_presence_of(aws, 'secret_access_key')
       validate_presence_of(aws, ::Rails.env)


### PR DESCRIPTION
Hi,

In case you like to use evironment variables in the configuration file.

Sample of one line in s3_config.yml:

aws_access_key_id: "<%=ENV["S3_ID"]%>"

May be there should be also a test case but please let me first know if the idea suit you.

Best regards,
Tilman
